### PR TITLE
Made game start successfully with unset GOPATH

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/g3n/engine/geometry"
+	"go/build"
 	"io/ioutil"
 	"runtime"
 	"strconv"
@@ -1219,6 +1220,9 @@ func main() {
 
 	// Manually scan the $GOPATH directories to find the data directory
 	rawPaths := os.Getenv("GOPATH")
+	if rawPaths == "" {
+		rawPaths = build.Default.GOPATH
+	}
 	paths := strings.Split(rawPaths, ":")
 	for _, j := range paths {
 		// Checks data path


### PR DESCRIPTION
Currently, the game fails to start if the `GOPATH` environment variable is unset. Setting `GOPATH` is optional as of Go 1.8 (which is the minimum version supported by this program).

This pull request makes gokoban fall back to `build.Default.GOPATH` from the `go/build` package if `GOPATH` is unset*, which should make the game run correctly with an unset `GOPATH`.

*Technically it will fall back if `GOPATH` is unset _or if `GOPATH` is an empty string_, since the lookup is performed using `os.Getenv` rather than `os.LookupEnv`. I don't think there's any logical reason to ever set `GOPATH` to an empty string though, so this shouldn't be an issue here. 